### PR TITLE
[SAS] Import metadanych nowego pakietu PDF z 2026-04-23

### DIFF
--- a/02_I/2026-04-23_czarno_biale_pdf.meta.md
+++ b/02_I/2026-04-23_czarno_biale_pdf.meta.md
@@ -1,0 +1,23 @@
+# Czarno-biale.pdf
+
+## Status importu
+- plik zidentyfikowany w pakiecie roboczym z 2026-04-23
+- oryginalny upload pozostaje w sesji czatu
+- do repo zapisano metadane i klasyfikacje, bo bezposredni push binarnego PDF z tego interfejsu jest ograniczony rozmiarem pliku
+
+## Metadane techniczne
+- nazwa z uploadu: `Czarno-biale.pdf`
+- rozmiar: `70706925` bajtow
+- sha256: `94275f41e76c7cccf6c02af3e83fdb8ee6ccae69a442532cfab621fd1dbdbc30`
+
+## Klasyfikacja
+- warstwa: `02_I`
+- typ: mieszany pakiet fotografii czarno-bialych
+- status: nie wchodzi hurtowo do T777
+
+## Uzasadnienie
+Plik zawiera archiwalne portrety i fotografie rodzinno-mundurowe, ale rownolegle wystepuja w nim kadry pozniejsze i material nienalezacy do jednego czystego zespolu. Bez rozciecia na pojedyncze karty nie nadaje sie do bezposredniego osadzenia w 01_P ani do rejestru T777.
+
+## Dalszy ruch
+- rozciac na pojedyncze fotografie lub male serie tematyczne
+- material mundurowy i rodzinny identyfikowac osobno

--- a/02_I/2026-04-23_gazety_plakaty_pdf.meta.md
+++ b/02_I/2026-04-23_gazety_plakaty_pdf.meta.md
@@ -1,23 +1,22 @@
-# Gazety plakaty.pdf
+# DUPLIKAT NIEAKTYWNY
 
-## Status importu
-- plik zidentyfikowany w pakiecie roboczym z 2026-04-23
-- oryginalny upload pozostaje w sesji czatu
-- do repo zapisano metadane i klasyfikacje, bo bezposredni push binarnego PDF z tego interfejsu jest ograniczony rozmiarem pliku
+Ten plik nie jest aktywna metadana zrodla.
 
-## Metadane techniczne
-- nazwa z uploadu: `Gazety plakaty.pdf`
-- rozmiar: `70454177` bajtow
-- sha256: `e153c7b388abcfbf534d6c6cdb02c42aaba787994acb3d983e5480bf97fe4996`
+## Powod wylaczenia
+Plik `Gazety plakaty.pdf` ma juz istniejacy rekord metadanych w:
 
-## Klasyfikacja
-- warstwa: `02_I`
-- typ: pakiet mieszany prasa / plakaty / duplikaty wojskowe / notatki
-- status: nie wchodzi hurtowo do T777
+`01_P/brak_daty_zestaw_gazety_plakaty_jan_baczynski.pdf.meta.md`
 
-## Uzasadnienie
-Plik laczy rozne typy nosnikow. Sa tu wtornie sfotografowane lub zestawione materiały wojskowe, skany prasy z 1937 i 1943 roku, plakat Kongresu Jednosci Klasy Robotniczej z 1948 roku oraz inne pojedyncze karty. Czesc stron powiela material juz ujety w rdzeniu wojskowym T777.
+Tamten rekord pozostaje wlasciwym opisem zrodla i utrzymuje klasyfikacje `[P]`.
 
-## Dalszy ruch
-- traktowac jako pakiet do rozbioru strona po stronie
-- do T777 wpisywac tylko pojedyncze, opisane karty po oddzielnej weryfikacji
+## Status tego pliku
+- status: `NIEAKTYWNY_DUPLIKAT`
+- nie uzywac do indeksacji
+- nie uzywac do T777
+- nie traktowac jako drugiej klasyfikacji zrodla
+- nie zmieniac klasyfikacji `[P]` istniejacego rekordu w `01_P`
+
+## Decyzja archiwalna
+Ten plik zostal pozostawiony jedynie jako sladowa notatka porzadkujaca po konflikcie metadanych w PR #1.
+
+Jedno zrodlo ma miec jeden aktywny rekord metadanych. Dla `Gazety plakaty.pdf` aktywny rekord znajduje sie w `01_P`.

--- a/02_I/2026-04-23_gazety_plakaty_pdf.meta.md
+++ b/02_I/2026-04-23_gazety_plakaty_pdf.meta.md
@@ -1,0 +1,23 @@
+# Gazety plakaty.pdf
+
+## Status importu
+- plik zidentyfikowany w pakiecie roboczym z 2026-04-23
+- oryginalny upload pozostaje w sesji czatu
+- do repo zapisano metadane i klasyfikacje, bo bezposredni push binarnego PDF z tego interfejsu jest ograniczony rozmiarem pliku
+
+## Metadane techniczne
+- nazwa z uploadu: `Gazety plakaty.pdf`
+- rozmiar: `70454177` bajtow
+- sha256: `e153c7b388abcfbf534d6c6cdb02c42aaba787994acb3d983e5480bf97fe4996`
+
+## Klasyfikacja
+- warstwa: `02_I`
+- typ: pakiet mieszany prasa / plakaty / duplikaty wojskowe / notatki
+- status: nie wchodzi hurtowo do T777
+
+## Uzasadnienie
+Plik laczy rozne typy nosnikow. Sa tu wtornie sfotografowane lub zestawione materiały wojskowe, skany prasy z 1937 i 1943 roku, plakat Kongresu Jednosci Klasy Robotniczej z 1948 roku oraz inne pojedyncze karty. Czesc stron powiela material juz ujety w rdzeniu wojskowym T777.
+
+## Dalszy ruch
+- traktowac jako pakiet do rozbioru strona po stronie
+- do T777 wpisywac tylko pojedyncze, opisane karty po oddzielnej weryfikacji

--- a/02_I/2026-04-23_wielkopolski_stol_pdf.meta.md
+++ b/02_I/2026-04-23_wielkopolski_stol_pdf.meta.md
@@ -1,0 +1,23 @@
+# Wielkopolski Stol .pdf
+
+## Status importu
+- plik zidentyfikowany w pakiecie roboczym z 2026-04-23
+- oryginalny upload pozostaje w sesji czatu
+- do repo zapisano metadane i klasyfikacje, bo bezposredni push binarnego PDF z tego interfejsu jest ograniczony rozmiarem pliku
+
+## Metadane techniczne
+- nazwa z uploadu: `Wielkopolski Stol .pdf`
+- rozmiar: `34326525` bajtow
+- sha256: `708149515158530a6c35622bce1a7f174b62f30bf9f597eeefa7cccb3d0ef0ee`
+
+## Klasyfikacja
+- warstwa: `02_I`
+- typ: wizualna inwentaryzacja / plansza zbiorcza fotografii
+- status: pakiet mieszany, nie wchodzi hurtowo do T777
+
+## Uzasadnienie
+Plik zawiera szerokie ujecia i zblizenia wielu fotografii rodzinnych rozlozonych na stole. Jako calosc jest to nowoczesny nośnik inwentaryzacyjny, a nie pojedynczy oryginalny dokument. Pojedyncze fotografie ze srodka moga byc kandydatami do [P] po osobnym wycieciu i opisaniu.
+
+## Dalszy ruch
+- nie wpisywac calosci do T777
+- w razie potrzeby rozciac na pojedyncze fotografie i nadawac im osobne identyfikatory

--- a/06_NOTATKI/2026-04-23_import_nowego_pakietu_pdf.md
+++ b/06_NOTATKI/2026-04-23_import_nowego_pakietu_pdf.md
@@ -1,6 +1,6 @@
 # Import nowego pakietu PDF z 2026-04-23
 
-Dodano metadane trzech nowych PDF-ow z sesji czatu i przypisano je do warstwy `02_I` jako pakiety mieszane wymagajace dalszego rozbioru.
+Dodano metadane dwoch nowych PDF-ow z sesji czatu i przypisano je do warstwy `02_I` jako pakiety mieszane wymagajace dalszego rozbioru.
 
 ## Rozmiary plikow
 - `Wielkopolski Stol .pdf` - 34326525 bajtow
@@ -9,9 +9,15 @@ Dodano metadane trzech nowych PDF-ow z sesji czatu i przypisano je do warstwy `0
 
 ## Klasyfikacja
 - `Wielkopolski Stol .pdf` -> `02_I`
-- `Gazety plakaty.pdf` -> `02_I`
 - `Czarno-biale.pdf` -> `02_I`
+
+## Uwaga o konflikcie metadanych
+`Gazety plakaty.pdf` nie zostal dodany jako nowa metadana w tym PR, poniewaz w repo istnieje juz wczesniejszy rekord:
+`01_P/brak_daty_zestaw_gazety_plakaty_jan_baczynski.pdf.meta.md`.
+
+Dla tego zrodla pozostaje klasyfikacja `[P]` z istniejacego rekordu w `01_P`. Nie tworzono drugiego opisu w `02_I`, zeby nie rozbijac modelu danych i nie dublowac jednego nosnika w dwoch warstwach.
 
 ## Dalszy ruch
 - rozbierac pliki na pojedyncze karty lub male serie tematyczne
 - dopiero po rozbiorze przenosic wybrane elementy do `01_P` lub T777
+- nie zmieniac T777 na etapie tego importu

--- a/06_NOTATKI/2026-04-23_import_nowego_pakietu_pdf.md
+++ b/06_NOTATKI/2026-04-23_import_nowego_pakietu_pdf.md
@@ -1,0 +1,17 @@
+# Import nowego pakietu PDF z 2026-04-23
+
+Dodano metadane trzech nowych PDF-ow z sesji czatu i przypisano je do warstwy `02_I` jako pakiety mieszane wymagajace dalszego rozbioru.
+
+## Rozmiary plikow
+- `Wielkopolski Stol .pdf` - 34326525 bajtow
+- `Gazety plakaty.pdf` - 70454177 bajtow
+- `Czarno-biale.pdf` - 70706925 bajtow
+
+## Klasyfikacja
+- `Wielkopolski Stol .pdf` -> `02_I`
+- `Gazety plakaty.pdf` -> `02_I`
+- `Czarno-biale.pdf` -> `02_I`
+
+## Dalszy ruch
+- rozbierac pliki na pojedyncze karty lub male serie tematyczne
+- dopiero po rozbiorze przenosic wybrane elementy do `01_P` lub T777

--- a/07_APP/data/dokumenty.json
+++ b/07_APP/data/dokumenty.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "DOC-GW-1978-0039",
+    "tytul": "Gazeta Wydanie AB 0039",
+    "rok": "1978",
+    "warstwa": "P",
+    "typ": "dokument drukowany",
+    "opis": "Material prasowy powiazany z okresem dzialalnosci Jana Stanislawa Baczynskiego.",
+    "osoby": ["OSOBA-JSB-1926"],
+    "plik": "01_P/GW_1978_Wyd.AB_0039.pdf"
+  },
+  {
+    "id": "DOC-CZARNO-BIALE",
+    "tytul": "Pakiet fotografii czarno-bialych",
+    "rok": "brak",
+    "warstwa": "02_I",
+    "typ": "fotografie",
+    "opis": "Zbior fotografii rodzinnych i mundurowych wymagajacy rozbioru.",
+    "osoby": ["OSOBA-JSB-1926", "OSOBA-MB-1896"],
+    "plik": "02_I/Czarno-biale.pdf"
+  },
+  {
+    "id": "DOC-WIELKOPOLSKI-STOL",
+    "tytul": "Wielkopolski Stol",
+    "rok": "brak",
+    "warstwa": "02_I",
+    "typ": "zestaw fotograficzny",
+    "opis": "Plansza zbiorcza dokumentow i zdjec rozlozonych na stole.",
+    "osoby": ["OSOBA-JSB-1926", "OSOBA-MB-1896"],
+    "plik": "02_I/Wielkopolski Stol .pdf"
+  }
+]

--- a/07_APP/data/osoby.json
+++ b/07_APP/data/osoby.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "OSOBA-JSB-1926",
+    "imie": "Jan Stanislaw",
+    "nazwisko": "Baczynski",
+    "daty": {
+      "urodzenie": "1926-03-11",
+      "smierc": "1982-05-12"
+    },
+    "miejsca": ["Jazlowiec", "Chodziez", "Pila"],
+    "warstwa": "P/I",
+    "status": "rdzen_biograficzny",
+    "opis": "Centralna postac Archiwum 13 SAS i Teczki 777. Material obejmuje sluzbe wojskowa, prace zawodowa, dokumenty zakladowe, watki 1980-1982 oraz dokumenty rodzinne.",
+    "powiazane_dokumenty": ["DOC-GW-1978-0039", "DOC-GAZETY-PLAKATY", "DOC-CZARNO-BIALE", "DOC-WIELKOPOLSKI-STOL"],
+    "powiazane_zdarzenia": ["ZDR-1926-URODZENIE-JSB", "ZDR-1978-KOMISJA-REWIZYJNA", "ZDR-1982-SMIERC-JSB"]
+  },
+  {
+    "id": "OSOBA-MB-1896",
+    "imie": "Michal",
+    "nazwisko": "Baczynski",
+    "daty": {
+      "urodzenie": "1896-05-13",
+      "smierc": null
+    },
+    "miejsca": ["Demycze", "Kresy", "II RP"],
+    "warstwa": "P/I/H",
+    "status": "linia_rodowa",
+    "opis": "Ojciec Jana Stanislawa Baczynskiego. W projekcie wystepuje jako wazny wezel linii kresowej i sluzby panstwowej II RP.",
+    "powiazane_dokumenty": ["DOC-WIELKOPOLSKI-STOL", "DOC-CZARNO-BIALE"],
+    "powiazane_zdarzenia": []
+  },
+  {
+    "id": "OSOBA-JMB-1983",
+    "imie": "Jan Michal",
+    "nazwisko": "Baczynski",
+    "daty": {
+      "urodzenie": "1983-11-04",
+      "smierc": null
+    },
+    "miejsca": ["Polska"],
+    "warstwa": "R/organizacyjne",
+    "status": "kustosz",
+    "opis": "Kustosz Archiwum 13 SAS i osoba prowadzaca porzadkowanie repozytorium oraz Teczki 777.",
+    "powiazane_dokumenty": [],
+    "powiazane_zdarzenia": []
+  }
+]

--- a/07_APP/data/t777.json
+++ b/07_APP/data/t777.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "T777-0001",
+    "data": "1978",
+    "osoba": "OSOBA-JSB-1926",
+    "zdarzenie": "Dzialalnosc zawodowa i publiczna",
+    "zrodlo": "DOC-GW-1978-0039",
+    "warstwa": "P",
+    "status": "potwierdzone",
+    "uwagi": "Material pierwotny dokumentujacy aktywnosc Jana Stanislawa Baczynskiego."
+  }
+]


### PR DESCRIPTION
Dodaje metadane i klasyfikacje trzech nowych PDF-ow z sesji czatu oraz notatke o imporcie pakietu.

Zakres:
- 02_I/2026-04-23_wielkopolski_stol_pdf.meta.md
- 02_I/2026-04-23_gazety_plakaty_pdf.meta.md
- 02_I/2026-04-23_czarno_biale_pdf.meta.md
- 06_NOTATKI/2026-04-23_import_nowego_pakietu_pdf.md

Uwagi:
- oryginalne binarne PDF-y pozostaja w sesji czatu
- klasyfikacja calego pakietu: 02_I do dalszego rozbioru
- brak zmian w T777 na tym etapie