### PR TITLE
docs(app): add local quick-start section in 07_APP README

### DIFF
--- a/07_APP/README.md
+++ b/07_APP/README.md
@@ -15,6 +15,13 @@ Starter przeglądarkowego frontu Archiwum 13.
 - [Pakiet roboczy SAS](../06_NOTATKI/pakiet_roboczy_SAS.md)
 - [Front HTML](./ARCHIWUM_13_START.html)
 
+## Szybki start (lokalnie)
+1. Uruchom podgląd HTML:
+   - otwórz `07_APP/ARCHIWUM_13_START.html` bezpośrednio w przeglądarce **lub**
+   - wystartuj prosty serwer statyczny (np. `python3 -m http.server`) i wejdź na `/07_APP/ARCHIWUM_13_START.html`.
+2. Traktuj README jako mapę przejścia między warstwami źródeł.
+3. Po każdej większej zmianie danych sprawdź, czy linki do CSV i notatek nadal działają.
+
 ## Co już działa
 - strona główna archiwum,
 - sekcje: zbiory, obiekty, osoby, miejsca, oś czasu,


### PR DESCRIPTION
### Motivation
- Provide an immediate local onboarding path to preview the HTML frontend without installing Omeka S so contributors can open the working frontend quickly and verify links to repo data.

### Description
- Add a `Szybki start (lokalnie)` section to `07_APP/README.md` that explains how to open `07_APP/ARCHIWUM_13_START.html` either directly or via a simple static server (`python3 -m http.server`) and adds a short maintenance note to re-check CSV and note links; this is a documentation-only change.

### Testing
- Ran `git diff --check` and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea835d805c8323a5a343091f410165)