### PR TITLE
Add `APP_BRIEF_TEMPLATE.md` — MVP app brief template

### DIFF
--- a/APP_BRIEF_TEMPLATE.md
+++ b/APP_BRIEF_TEMPLATE.md
@@ -1,42 +1,78 @@
-# Szablon opisu aplikacji (MVP)
+# Szablon opisu aplikacji (MVP) — wersja wdrożeniowa
 
-Użyj tego szablonu, jeśli chcesz szybko przygotować wymagania do implementacji i PR.
+Ten plik służy do przygotowania **jednego źródła prawdy** przed kodowaniem.
+Wypełnij sekcje poniżej, a następnie użyj ich jako podstawy do implementacji i PR.
 
-## 1) Podstawy
-- Nazwa aplikacji:
-- Typ: (web / mobile / desktop)
+## 0) Kontekst
+- Nazwa projektu:
+- Właściciel biznesowy / decyzyjny:
+- Data przygotowania briefu:
+- Link do zadania (Jira/Notion/GitHub Issue):
+
+## 1) Problem i cel
+- Jaki problem rozwiązujemy:
 - Dla kogo:
-- Termin MVP:
+- Dlaczego teraz:
+- Cel mierzalny (np. czas, koszt, konwersja):
 
-## 2) Zakres MVP (co robimy teraz)
+## 2) Zakres MVP (IN)
 - Funkcja #1:
 - Funkcja #2:
 - Funkcja #3:
+- Minimalny przepływ użytkownika (krok po kroku):
+  1.
+  2.
+  3.
 
-## 3) Poza zakresem (czego **nie** robimy teraz)
+## 3) Poza zakresem (OUT)
+Wpisz rzeczy, których **nie robimy** w tej iteracji:
+- 
+- 
 - 
 
-## 4) Kryteria akceptacji
+## 4) Wymagania funkcjonalne
 - [ ] Użytkownik może ...
+- [ ] System waliduje ...
 - [ ] System zapisuje ...
-- [ ] Widoczny jest komunikat ...
+- [ ] Widoczny jest komunikat sukcesu/błędu ...
 
-## 5) Wdrożenie
+## 5) Wymagania niefunkcjonalne
+- Bezpieczeństwo (np. logowanie, role, RODO):
+- Wydajność (np. czas odpowiedzi):
+- Dostępność (np. mobile-first, WCAG):
+- Logowanie błędów / monitoring:
+
+## 6) Dane i integracje
+- Źródło danych (API/DB/pliki):
+- Pola obowiązkowe:
+- Integracje zewnętrzne:
+- Ograniczenia techniczne:
+
+## 7) Kryteria akceptacji (DoD)
+- [ ] Scenariusz A działa: ...
+- [ ] Scenariusz B działa: ...
+- [ ] Brak błędów krytycznych w konsoli/logach
+- [ ] Zmiana opisana w README/changelogu
+
+## 8) Plan wdrożenia
+- Środowisko: (dev / staging / prod)
 - Gdzie wdrażamy: (GitHub / Vercel / Render / serwer)
-- Wymagane sekrety/klucze:
-- Czy potrzebny staging:
+- Sekrety/klucze wymagane do uruchomienia:
+- Plan rollbacku:
 
-## 6) Materiały wejściowe
-- Link do repo:
-- Linki do makiet/screenshotów:
-- Dodatkowe notatki:
+## 9) Checklista PR
+- [ ] Zakres PR zgodny z sekcją „Zakres MVP (IN)”
+- [ ] Dodane/odświeżone testy adekwatne do zmian
+- [ ] Opis PR zawiera: cel, zakres, ryzyka, testy, rollout
+- [ ] Reviewer ma komplet kontekstu (linki, screeny, dane testowe)
 
 ---
 
-## Minimalna wersja „na szybko”
+## Minimalna wersja „na szybko” (60 sekund)
 Jeśli nie masz czasu, podaj tylko:
-1. Typ aplikacji
-2. 2 najważniejsze funkcje
+1. Typ aplikacji (web/mobile/desktop)
+2. Dwie najważniejsze funkcje
 3. Termin MVP
+4. Jedno kryterium akceptacji („po czym poznamy, że działa”)
 
-Na tej podstawie można przygotować plan implementacji i PR.
+To wystarcza, żeby przygotować sensowny plan implementacji i PR.

--- a/APP_BRIEF_TEMPLATE.md
+++ b/APP_BRIEF_TEMPLATE.md
@@ -1,0 +1,42 @@
+# Szablon opisu aplikacji (MVP)
+
+Użyj tego szablonu, jeśli chcesz szybko przygotować wymagania do implementacji i PR.
+
+## 1) Podstawy
+- Nazwa aplikacji:
+- Typ: (web / mobile / desktop)
+- Dla kogo:
+- Termin MVP:
+
+## 2) Zakres MVP (co robimy teraz)
+- Funkcja #1:
+- Funkcja #2:
+- Funkcja #3:
+
+## 3) Poza zakresem (czego **nie** robimy teraz)
+- 
+
+## 4) Kryteria akceptacji
+- [ ] Użytkownik może ...
+- [ ] System zapisuje ...
+- [ ] Widoczny jest komunikat ...
+
+## 5) Wdrożenie
+- Gdzie wdrażamy: (GitHub / Vercel / Render / serwer)
+- Wymagane sekrety/klucze:
+- Czy potrzebny staging:
+
+## 6) Materiały wejściowe
+- Link do repo:
+- Linki do makiet/screenshotów:
+- Dodatkowe notatki:
+
+---
+
+## Minimalna wersja „na szybko”
+Jeśli nie masz czasu, podaj tylko:
+1. Typ aplikacji
+2. 2 najważniejsze funkcje
+3. Termin MVP
+
+Na tej podstawie można przygotować plan implementacji i PR.


### PR DESCRIPTION
### Motivation
- Provide a short, standardized template for describing MVP app requirements and preparing implementation and PR-ready briefs.

### Description
- Add `APP_BRIEF_TEMPLATE.md`, a Polish-language template that outlines basic app details, MVP scope, out-of-scope items, acceptance criteria, deployment notes, and a minimal quick-version checklist.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8b97798883238c3b8ddfdf32da42)